### PR TITLE
Fixed bug of Python

### DIFF
--- a/kindlefere/bin/sdr-cleaner/sdr_cleaner.sh
+++ b/kindlefere/bin/sdr-cleaner/sdr_cleaner.sh
@@ -5,6 +5,11 @@
 #------------------------
 
 KINDLE_PATH=/chroot/mnt/us
+if [[ $PATH != *"/mnt/us/python/bin"* ]]
+    then
+        export PATH=$PATH:/mnt/us/python/bin
+fi
+alias python="python2.7"
 
 # sdr_cleaner
 cd ${KINDLE_PATH}/extensions/kindlefere/bin/sdr-cleaner


### PR DESCRIPTION
which causes the plugin to be unable to work
修复了一个导致无法工作的问题
因为 Python 插件似乎需要手动用绝对路径……
直接用 GitHub 在线编辑的所以就不要吐槽 branch name 了（捂脸逃